### PR TITLE
Fix query params bug and use summary for tool names

### DIFF
--- a/src/parser/extract-tools.ts
+++ b/src/parser/extract-tools.ts
@@ -62,7 +62,7 @@ export function extractToolsFromApi(
       }
 
       // Generate a unique name for the tool
-      let baseName = operation.operationId || generateOperationId(method, path);
+      let baseName = operation.summary || generateOperationId(method, path);
       if (!baseName) continue;
 
       // Sanitize the name to be MCP-compatible (only a-z, 0-9, _, -)

--- a/src/utils/security.ts
+++ b/src/utils/security.ts
@@ -412,7 +412,13 @@ async function executeApiTool(
                 urlPath = urlPath.replace(\`{\${param.name}}\`, encodeURIComponent(String(value)));
             }
             else if (param.in === 'query') {
-                queryParams[param.name] = value;
+                // Convert arrays to comma-separated strings for query parameters
+                queryParams[param.name] = Array.isArray(value)
+                  ? value
+                      .filter((v) => v !== undefined && v !== null)
+                      .map((v) => String(v))
+                      .join(',')
+                  : value;            
             }
             else if (param.in === 'header') {
                 headers[param.name.toLowerCase()] = String(value);


### PR DESCRIPTION
Fix 2 issues

* Array query params need to be joined by commas or else Axios renders it very strangely
* Use the OpenAPI spec summary field instead of the operation id. This will use Create a Contact instead of createContactUsingPost1 for tool names.